### PR TITLE
Fixed typo in dropbar.lua

### DIFF
--- a/lua/plugins/dropbar.lua
+++ b/lua/plugins/dropbar.lua
@@ -6,7 +6,7 @@ local judge_version = function()
   end
 end
 
-local remove_dropba_color = function()
+local remove_dropbar_color = function()
   -- 防止 dropbar 显示 cmp 的背景颜色
   local dropbar_groups = {
     "DropBarIconKindVariable",
@@ -45,6 +45,6 @@ return {
   cond = judge_version(),
   config = function()
     require("dropbar").setup({})
-    remove_dropba_color()
+    remove_dropbar_color()
   end,
 }


### PR DESCRIPTION
Fixed the typo in the name of remove_dropbar_color